### PR TITLE
Publish response error code with exception

### DIFF
--- a/src/apiclient.class.php
+++ b/src/apiclient.class.php
@@ -571,7 +571,7 @@
             $result = $this->build_result($xml);
 
             if ($result['@attributes']['status'] != self::RESPONSE_TYPE_OK) {
-                throw new apiclient_response_exception('(' . $result['@attributes']['status_code'] . ') ' . $result['@attributes']['status_description']);
+                throw new apiclient_response_exception('(' . $result['@attributes']['status_code'] . ') ' . $result['@attributes']['status_description'], (int)$result['@attributes']['status_code']);
             }
 
             return $result;


### PR DESCRIPTION
I would like to see the response status code published with the exception since this allows developers to check programatically why an exception occurred. Currently `getCode()` on a exception returns the default code (`0`), with this minor change `getCode` returns a _proper_ value.