### PR TITLE
remove invalid characters from xml

### DIFF
--- a/src/apiclient.class.php
+++ b/src/apiclient.class.php
@@ -589,6 +589,7 @@
 
             utils::check_string($xml, 'xml');
 
+            $xml = preg_replace('/[^\x9\xa\x20-\xD7FF\xE000-\xFFFD]/', '', $xml);
             $xml = @simplexml_load_string($xml, NULL, LIBXML_NOCDATA);
 
             if (!$xml) {


### PR DESCRIPTION
this prevents parse xml errors if the xml response contains invalid characters